### PR TITLE
containerlist; try with errgroup

### DIFF
--- a/daemon/list.go
+++ b/daemon/list.go
@@ -18,6 +18,7 @@ import (
 	"github.com/docker/docker/image"
 	"github.com/docker/go-connections/nat"
 	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
 )
 
 var acceptedPsFilterTags = map[string]bool{
@@ -105,11 +106,7 @@ func (daemon *Daemon) Containers(ctx context.Context, config *containertypes.Lis
 		return nil, err
 	}
 
-	var (
-		view       = daemon.containersReplica.Snapshot()
-		containers = []*containertypes.Summary{}
-	)
-
+	view := daemon.containersReplica.Snapshot()
 	filter, err := daemon.foldFilter(ctx, view, config)
 	if err != nil {
 		return nil, err
@@ -118,68 +115,63 @@ func (daemon *Daemon) Containers(ctx context.Context, config *containertypes.Lis
 	// shortcut to only look at a subset of containers if specific name
 	// or ID matches were provided by the user--otherwise we potentially
 	// end up querying many more containers than intended
+	//
+	// TODO (thaJeztah): given containersReplica.Snapshot() provides a "consistent read-only view of the database" (which indicates "de-referenced copy", is there any reason we wouldn't use a []*container.Snapshot (pointer-slice)?.
 	containerList, err := daemon.filterByNameIDMatches(view, filter)
 	if err != nil {
 		return nil, err
 	}
 	numContainers := len(containerList)
-	results := make(chan *containertypes.Summary, numContainers)
 
 	// Get the info for each container in the list; this can be slow so we
 	// dispatch a set number of worker goroutines to do the jobs. We choose
 	// log2(numContainers) workers to avoid creating too many goroutines
 	// for large number of containers.
-	numWorkers := log2(numContainers)
+	numWorkers := int(math.Log2(float64(numContainers)))
 	if numWorkers < 1 {
 		numWorkers = 1
 	}
-	workers := make(chan struct{}, numWorkers)
+	resultsMut := sync.Mutex{}
+	results := make([]*containertypes.Summary, 0, min(len(containerList), filter.Limit))
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.SetLimit(numWorkers)
+	// eg.SetLimit(runtime.NumCPU() * 2) // TODO(thajeztah): see if it makes a difference? see https://github.com/moby/moby/pull/49365/files#r1938445482
 
-	var wg sync.WaitGroup
-	for i := range containerList {
-		currentContainer := &containerList[i]
-		switch includeContainerInList(currentContainer, filter) {
+	for _, ctr := range containerList {
+		switch includeContainerInList(&ctr, filter) {
 		case excludeContainer:
 			continue
 		case stopIteration:
 			break
 		default:
 			filter.idx++
-			workers <- struct{}{} // acquire worker slot
-			wg.Add(1)
 
-			// worker function
-			go func(c *container.Snapshot) {
-				defer func() {
-					wg.Done()
-					<-workers // release worker slot
-				}()
-
+			eg.Go(func() error {
 				// refresh the container image info (in case the image changed in
 				// the repository)
-				newC := daemon.refreshImage(ctx, currentContainer)
+				newC := daemon.refreshImage(ctx, &ctr)
 
 				// get the image size (calculation is slow)
 				if filter.Size {
-					sizeRw, sizeRootFs, err := daemon.imageService.GetContainerLayerSize(ctx, newC.ID)
+					var err error
+					newC.SizeRw, newC.SizeRootFs, err = daemon.imageService.GetContainerLayerSize(ctx, newC.ID)
 					if err != nil {
-						return
+						return err
 					}
-					newC.SizeRw = sizeRw
-					newC.SizeRootFs = sizeRootFs
 				}
-				results <- newC
-			}(currentContainer)
+				resultsMut.Lock()
+				results = append(results, newC)
+				resultsMut.Unlock()
+				return nil
+			})
 		}
 	}
-	go func() {
-		wg.Wait()
-		close(results)
-	}()
-	for c := range results {
-		containers = append(containers, c)
+
+	if err := eg.Wait(); err != nil {
+		return nil, err
 	}
-	return containers, nil
+
+	return results, nil
 }
 
 func (daemon *Daemon) filterByNameIDMatches(view *container.View, filter *listContext) ([]container.Snapshot, error) {
@@ -662,9 +654,4 @@ func populateImageFilterByParents(ctx context.Context, ancestorMap map[image.ID]
 		ancestorMap[imageID] = true
 	}
 	return nil
-}
-
-// log2 calculates the floor of log base 2 of a number.
-func log2(n int) int {
-	return int(math.Log2(float64(n)))
 }

--- a/daemon/list_test.go
+++ b/daemon/list_test.go
@@ -3,7 +3,6 @@ package daemon
 import (
 	"context"
 	"fmt"
-	"math"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -213,6 +212,6 @@ func TestLimitFilter(t *testing.T) {
 	limit := rand.Intn(64)
 	containerList, err := d.Containers(context.Background(), &containertypes.ListOptions{Limit: limit})
 	assert.NilError(t, err)
-	expectedListLen := int(math.Min(float64(num), float64(limit)))
+	expectedListLen := min(num, limit)
 	assert.Assert(t, is.Len(containerList, expectedListLen))
 }


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/49365


See what it looks like if we use an errgroup instead of manually handling concurrency with a waitgroup + channels.

Also replacing the results channel for a slice + mutex

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

